### PR TITLE
feat: wrap returned elements in jQuery, close #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [cypress/integration/spec.js](cypress/integration/spec.js)
 
 ## Roadmap
 
-- [ ] wrap returned DOM nodes in jQuery [#2](https://github.com/cypress-io/cypress-xpath/issues/2)
+- [x] wrap returned DOM nodes in jQuery [#2](https://github.com/cypress-io/cypress-xpath/issues/2)
 - [ ] retry the assertion that follows [#3](https://github.com/cypress-io/cypress-xpath/issues/3)
 - [ ] add TypeScript definitions [#4](https://github.com/cypress-io/cypress-xpath/issues/4)
 - [ ] search from the previous subject element [#5](https://github.com/cypress-io/cypress-xpath/issues/5)

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -5,13 +5,35 @@ describe('cypress-xpath', () => {
     expect(cy).property('xpath').to.be.a('function')
   })
 
-  it('finds h1', () => {
-    cy.visit('cypress/integration/index.html')
-    cy.xpath('//h1').should('have.length', 1)
-  })
+  context('elements', () => {
+    beforeEach(() => {
+      cy.visit('cypress/integration/index.html')
+    })
 
-  it('gets h1 text', () => {
-    cy.visit('cypress/integration/index.html')
-    cy.xpath('//h1/text()').its('0.textContent').should('equal', 'cypress-xpath')
+    it('finds h1', () => {
+      cy.xpath('//h1').should('have.length', 1)
+      .then((el$) => {
+        expect(el$).to.have.property('jquery')
+      })
+    })
+
+    it('gets h1 text', () => {
+      cy.xpath('//h1/text()').its('0.textContent').should('equal', 'cypress-xpath')
+    })
+
+    describe('primitives', () => {
+      it('counts h1 elements', () => {
+        cy.xpath('count(//h1)').should('equal', 1)
+      })
+
+      it('returns h1 text content', () => {
+        cy.xpath('string(//h1)').should('equal', 'cypress-xpath')
+      })
+
+      it('returns boolean', () => {
+        cy.xpath('boolean(//h1)').should('be.true')
+        cy.xpath('boolean(//h2)').should('be.false')
+      })
+    })
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -24,30 +24,59 @@ const xpath = (selector) => {
   const isBoolean = (xpathResult) => xpathResult.resultType === XPathResult.BOOLEAN_TYPE
   const booleanResult = (xpathResult) => xpathResult.booleanValue
 
-  Cypress.log({
-    name: 'xpath',
-    message: selector,
-    consoleProps () {
-      return {
-        'XPath': selector,
-      }
-    },
-  })
-
   let nodes = []
   const document = cy.state('window').document
   let iterator = document.evaluate(selector, document)
 
   if (isNumber(iterator)) {
-    return numberResult(iterator)
+    const result = numberResult(iterator)
+    Cypress.log({
+      name: 'xpath',
+      message: selector,
+      $el: nodes,
+      consoleProps () {
+        return {
+          'XPath': selector,
+          type: 'number',
+          result
+        }
+      },
+    })
+    return result
   }
 
   if (isString(iterator)) {
-    return stringResult(iterator)
+    const result = stringResult(iterator)
+    Cypress.log({
+      name: 'xpath',
+      message: selector,
+      $el: nodes,
+      consoleProps () {
+        return {
+          'XPath': selector,
+          type: 'string',
+          result
+        }
+      },
+    })
+    return result
   }
 
   if (isBoolean(iterator)) {
-    return booleanResult(iterator)
+    const result = booleanResult(iterator)
+    Cypress.log({
+      name: 'xpath',
+      message: selector,
+      $el: nodes,
+      consoleProps () {
+        return {
+          'XPath': selector,
+          type: 'boolean',
+          result
+        }
+      },
+    })
+    return result
   }
 
   try {
@@ -65,7 +94,18 @@ const xpath = (selector) => {
 
   // TODO set found elements on the command log?
 
-  return nodes
+  Cypress.log({
+    name: 'xpath',
+    message: selector,
+    $el: nodes,
+    consoleProps () {
+      return {
+        'XPath': selector,
+      }
+    },
+  })
+
+  return Cypress.$(nodes)
 }
 
 Cypress.Commands.add('xpath', xpath)


### PR DESCRIPTION
- closes #2 

returns primitive elements unwrapped, but for nodes, returns `Cypress.$(nodes)`