### PR TITLE
Provide jQuery-wrapped elements to upcoming assertions

### DIFF
--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -23,6 +23,12 @@ describe('cypress-xpath', () => {
       })
     })
 
+    it('returns primitives as is', () => {
+      cy.xpath('string(//h1)').then(el$ => {
+        expect(el$).to.not.have.property('jquery')
+      })
+    })
+
     it('gets h1 text', () => {
       cy.xpath('//h1/text()')
         .its('0.textContent')

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -29,6 +29,12 @@ describe('cypress-xpath', () => {
       })
     })
 
+    it('provides jQuery wrapped elements to assertions', () => {
+      cy.xpath('//h1').should(el$ => {
+        expect(el$).to.have.property('jquery')
+      })
+    })
+
     it('gets h1 text', () => {
       cy.xpath('//h1/text()')
         .its('0.textContent')

--- a/src/index.js
+++ b/src/index.js
@@ -98,6 +98,9 @@ const xpath = (selector, options = {}) => {
 
   const resolveValue = () => {
     return Cypress.Promise.try(getValue).then(value => {
+      if (!isPrimitive(value)) {
+        value = Cypress.$(value)
+      }
       return cy.verifyUpcomingAssertions(value, options, {
         onRetry: resolveValue,
       })
@@ -107,10 +110,7 @@ const xpath = (selector, options = {}) => {
   return resolveValue().then((value) => {
     // TODO set found elements on the command log?
     Cypress.log(log)
-    if (isPrimitive(value)) {
-      return value
-    }
-    return Cypress.$(value)
+    return value
   })
 
 


### PR DESCRIPTION
This patch ensures that values provided to upcoming assertions are also wrapped in jQuery. Credit goes to @Lakitna for [showing me the issue](https://gitter.im/cypress-io/cypress?at=5cc2f26a5b3f941aa595b5ec).

