### PR TITLE
feat: log yielded elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,7 @@ const xpath = (subject, selector, options = {}) => {
       log.consoleProps = () => {
         return {
           'XPath': selector,
+          'result': nodes.length === 1 ? nodes[0] : nodes
         }
       }
 


### PR DESCRIPTION
This behaves in the same way as `cy.get` in that it avoids logging an array when a single element is yielded [1-2].

[1] https://github.com/cypress-io/cypress/blob/v3.3.1/packages/driver/src/cy/commands/querying.coffee#L111
[2] https://github.com/cypress-io/cypress/blob/v3.3.1/packages/driver/src/dom/elements.js#L625-L627

I haven't added any tests for this, as there aren't any for when the result are of primitive type either.