### PR TITLE
fix: invoke evaluate() on correct document node (Firefox support)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ const xpath = (subject, selector, options = {}) => {
       contextNode = cy.state('window').document
     }
 
-    let iterator = document.evaluate(selector, contextNode)
+    let iterator = (contextNode.ownerDocument || contextNode).evaluate(selector, contextNode)
 
     if (isNumber(iterator)) {
       const result = numberResult(iterator)


### PR DESCRIPTION
I guess the document node of the script's runtime isn't necessarily the same document node of a subject, which Firefox did not like. Hence, this adds support for Firefox.