### PR TITLE
fix: updated browser to fix CI failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   cypress: cypress-io/cypress@2
 jobs:
   release:
-    executor: cypress/browsers-chrome78-ff70
+    executor: cypress/browsers-chrome100-ff99-edge
     steps:
       - attach_workspace:
           at: ~/
@@ -14,13 +14,13 @@ workflows:
     jobs:
       - cypress/install:
           name: Install
-          executor: cypress/browsers-chrome78-ff70
+          executor: cypress/browsers-chrome100-ff99-edge
 
       - cypress/run:
           name: Electron tests
           requires:
             - Install
-          executor: cypress/browsers-chrome78-ff70
+          executor: cypress/browsers-chrome100-ff99-edge
           install-command: echo 'Nothing to install in this job'
           no-workspace: true
 
@@ -28,7 +28,7 @@ workflows:
           name: Chrome tests
           requires:
             - Install
-          executor: cypress/browsers-chrome78-ff70
+          executor: cypress/browsers-chrome100-ff99-edge
           browser: chrome
           install-command: echo 'Nothing to install in this job'
           no-workspace: true
@@ -37,7 +37,7 @@ workflows:
           name: Firefox tests
           requires:
             - Install
-          executor: cypress/browsers-chrome78-ff70
+          executor: cypress/browsers-chrome100-ff99-edge
           browser: firefox
           install-command: echo 'Nothing to install in this job'
           no-workspace: true


### PR DESCRIPTION
Currently, Circle CI jobs are failing due to the old version of the firefox browser, updated the browser versions. 

Current job failure snapshot - 

https://app.circleci.com/pipelines/github/cypress-io/cypress-xpath/464/workflows/c065dce6-ab82-4350-a181-dcd395245e08/jobs/1487

[Executor doc](https://github.com/cypress-io/circleci-orb/blob/master/docs/executors.md) info for reference 